### PR TITLE
Tune SOC for real-world dash values

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -111,7 +111,7 @@
 { "hdr": "79B", "rax": "7BB", "fcm1": true, "cmd": {"21": "01"}, "freq": 1,
   "signals": [
     {"id": "LEAF_HVBAT_VOLT", "path": "Battery", "fmt": {"bix": 144, "len": 16, "max": 655,  "div": 100,              "unit": "volts"       }, "name": "High voltage battery voltage"},
-    {"id": "LEAF_HVBAT_SOC",  "path": "Battery", "fmt": {"bix": 248, "len": 24, "max": 100,  "div": 10000, "add": -4, "unit": "percent"     }, "name": "High voltage battery charge",   "suggestedMetric": "stateOfCharge"},
+    {"id": "LEAF_HVBAT_SOC",  "path": "Battery", "fmt": {"bix": 248, "len": 24, "max": 100,  "div": 8400, "add": -16, "unit": "percent"     }, "name": "High voltage battery charge",   "suggestedMetric": "stateOfCharge"},
     {"id": "LEAF_HVBAT_CAP",  "path": "Battery", "fmt": {"bix": 280, "len": 24, "max": 1000, "div": 10000,            "unit": "ampereHours" }, "name": "High voltage battery capacity"}
   ]},
 { "hdr": "79B", "rax": "7BB", "fcm1": true, "cmd": {"21": "61"}, "freq": 3600,


### PR DESCRIPTION
Based on the following real-world reported dash values:

```
   hex    dec                scaled
0E7E89 -> 949,897 / 10,000 = 94.9897 (raw), dash reports 97, ratio = 0.9793
096F99 -> 618,393 / 10,000 = 61.8393 (raw), dash reports 59, ratio = 1.0481
066BFC -> 420,860 / 10,000 = 42.086 (raw),  dash reports 34, ratio = 1.2378
05E344 -> 385,860 / 10,000 = 38.586 (raw),  dash reports 30, ratio = 1.2862
04C635 -> 312,885 / 10,000 = 31.2885 (raw), dash reports 21, ratio = 1.4899
```

Grapher visualization:

<img width="1087" alt="Screenshot 2024-07-16 at 10 14 54 PM" src="https://github.com/user-attachments/assets/c6752569-166d-46b0-be08-109cda86d727">
