### PR TITLE
Further adjustments of the SOC scaling curve

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -111,7 +111,7 @@
 { "hdr": "79B", "rax": "7BB", "fcm1": true, "cmd": {"21": "01"}, "freq": 1,
   "signals": [
     {"id": "LEAF_HVBAT_VOLT", "path": "Battery", "fmt": {"bix": 144, "len": 16, "max": 655,  "div": 100,              "unit": "volts"       }, "name": "High voltage battery voltage"},
-    {"id": "LEAF_HVBAT_SOC",  "path": "Battery", "fmt": {"bix": 248, "len": 24, "max": 100,  "div": 8400, "add": -16, "unit": "percent"     }, "name": "High voltage battery charge",   "suggestedMetric": "stateOfCharge"},
+    {"id": "LEAF_HVBAT_SOC",  "path": "Battery", "fmt": {"bix": 248, "len": 24, "max": 100,  "div": 8190, "add": -17, "unit": "percent"     }, "name": "High voltage battery charge",   "suggestedMetric": "stateOfCharge"},
     {"id": "LEAF_HVBAT_CAP",  "path": "Battery", "fmt": {"bix": 280, "len": 24, "max": 1000, "div": 10000,            "unit": "ampereHours" }, "name": "High voltage battery capacity"}
   ]},
 { "hdr": "79B", "rax": "7BB", "fcm1": true, "cmd": {"21": "61"}, "freq": 3600,


### PR DESCRIPTION
Readings used to calculate this new scaling:

<img width="529" alt="Screenshot 2024-07-17 at 9 06 19 AM" src="https://github.com/user-attachments/assets/34e6cb45-54d9-4733-b135-07ab3128995b">
